### PR TITLE
fix: iOS Chrome の CORS エラーを修正

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,8 +19,7 @@ interface Env {
 }
 
 const ALLOWED_ORIGINS = [
-  'https://blog.milkmaccya.com',
-  'http://blog.milkmaccya.com',
+  /^https?:\/\/blog\.milkmaccya\.com$/,
   /^https?:\/\/.*-mm2-blog\.milkmaccya2\.workers\.dev$/,
   /^http:\/\/localhost:\d+$/,
 ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,8 @@ export default {
       apiKey: env.ANTHROPIC_API_KEY,
     });
 
-    const streamResponse = createUIMessageStreamResponse({
+    return createUIMessageStreamResponse({
+      headers: corsHeaders(origin),
       stream: createUIMessageStream({
         execute: ({ writer }) => {
           const sentSourceUrls = new Set<string>();
@@ -120,16 +121,6 @@ export default {
           writer.merge(result.toUIMessageStream());
         },
       }),
-    });
-
-    const headers = new Headers(streamResponse.headers);
-    for (const [key, value] of Object.entries(corsHeaders(origin))) {
-      headers.set(key, value);
-    }
-    return new Response(streamResponse.body, {
-      status: streamResponse.status,
-      statusText: streamResponse.statusText,
-      headers,
     });
   },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,8 @@ interface Env {
 
 const ALLOWED_ORIGINS = [
   'https://blog.milkmaccya.com',
-  /^https:\/\/.*-mm2-blog\.milkmaccya2\.workers\.dev$/,
+  'http://blog.milkmaccya.com',
+  /^https?:\/\/.*-mm2-blog\.milkmaccya2\.workers\.dev$/,
   /^http:\/\/localhost:\d+$/,
 ];
 
@@ -84,8 +85,7 @@ export default {
       apiKey: env.ANTHROPIC_API_KEY,
     });
 
-    return createUIMessageStreamResponse({
-      headers: corsHeaders(origin),
+    const streamResponse = createUIMessageStreamResponse({
       stream: createUIMessageStream({
         execute: ({ writer }) => {
           const sentSourceUrls = new Set<string>();
@@ -120,6 +120,16 @@ export default {
           writer.merge(result.toUIMessageStream());
         },
       }),
+    });
+
+    const headers = new Headers(streamResponse.headers);
+    for (const [key, value] of Object.entries(corsHeaders(origin))) {
+      headers.set(key, value);
+    }
+    return new Response(streamResponse.body, {
+      status: streamResponse.status,
+      statusText: streamResponse.statusText,
+      headers,
     });
   },
 };


### PR DESCRIPTION
## Summary

- `http://blog.milkmaccya.com` を `ALLOWED_ORIGINS` に追加。iOS Chrome は HTTPS ページからのリクエストでも `http://` な Origin ヘッダーを送ることがあり、許可リストにマッチせず CORS エラーになっていた
- `createUIMessageStreamResponse` にヘッダーを渡しても内部で上書きされる問題を修正。レスポンスを一度受け取り、新しい `Response` を生成して CORS ヘッダーを確実に付加するよう変更

## Test plan

- [ ] iOS Chrome でチャットが動作することを確認
- [ ] Safari (iOS/desktop) でチャットが引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)